### PR TITLE
enable get_value_3d for image layers

### DIFF
--- a/napari/layers/_scalar_field/scalar_field.py
+++ b/napari/layers/_scalar_field/scalar_field.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import types
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 import numpy as np
 from numpy import typing as npt
@@ -26,6 +26,7 @@ from napari.utils.colormaps import AVAILABLE_COLORMAPS
 from napari.utils.events import Event
 from napari.utils.events.event import WarningEmitter
 from napari.utils.events.event_utils import connect_no_arg
+from napari.utils.geometry import clamp_point_to_bounding_box
 from napari.utils.naming import magic_name
 from napari.utils.translations import trans
 
@@ -458,6 +459,7 @@ class ScalarFieldBase(Layer, ABC):
         self._custom_interpolation_kernel_2d = np.array(value, np.float32)
         self.events.custom_interpolation_kernel_2d()
 
+    @abstractmethod
     def _raw_to_displayed(self, raw: np.ndarray) -> np.ndarray:
         """Determine displayed image from raw image.
 
@@ -587,6 +589,106 @@ class ScalarFieldBase(Layer, ABC):
             value = (self.data_level, value)
 
         return value
+
+    def _get_value_ray(
+        self,
+        start_point: Optional[np.ndarray],
+        end_point: Optional[np.ndarray],
+        dims_displayed: list[int],
+    ) -> Optional[int]:
+        """Get the first non-background value encountered along a ray.
+
+        Parameters
+        ----------
+        start_point : np.ndarray
+            (n,) array containing the start point of the ray in data coordinates.
+        end_point : np.ndarray
+            (n,) array containing the end point of the ray in data coordinates.
+        dims_displayed : List[int]
+            The indices of the dimensions currently displayed in the viewer.
+
+        Returns
+        -------
+        value : Optional[int]
+            The first non-background value encountered along the ray. If none
+            was encountered or the viewer is in 2D mode, returns None.
+        """
+        if start_point is None or end_point is None:
+            return None
+        if len(dims_displayed) == 3:
+            # only use get_value_ray on 3D for now
+            # we use dims_displayed because the image slice
+            # has its dimensions  in th same order as the vispy
+            # Volume
+            # Account for downsampling in the case of multiscale
+            # -1 means lowest resolution here.
+            start_point = (
+                start_point[dims_displayed]
+                / self.downsample_factors[-1][dims_displayed]
+            )
+            end_point = (
+                end_point[dims_displayed]
+                / self.downsample_factors[-1][dims_displayed]
+            )
+            start_point = cast(np.ndarray, start_point)
+            end_point = cast(np.ndarray, end_point)
+            sample_ray = end_point - start_point
+            length_sample_vector = np.linalg.norm(sample_ray)
+            n_points = int(2 * length_sample_vector)
+            sample_points = np.linspace(
+                start_point, end_point, n_points, endpoint=True
+            )
+            im_slice = self._slice.image.raw
+            # ensure the bounding box is for the proper multiscale level
+            bounding_box = self._display_bounding_box_at_level(
+                dims_displayed, self.data_level
+            )
+            # the display bounding box is returned as a closed interval
+            # (i.e. the endpoint is included) by the method, but we need
+            # open intervals in the code that follows, so we add 1.
+            bounding_box[:, 1] += 1
+
+            clamped = clamp_point_to_bounding_box(
+                sample_points,
+                bounding_box,
+            ).astype(int)
+            values = im_slice[tuple(clamped.T)]
+            return self._calculate_value_from_ray(values)
+
+        return None
+
+    @abstractmethod
+    def _calculate_value_from_ray(self, values):
+        raise NotImplementedError
+
+    def _get_value_3d(
+        self,
+        start_point: Optional[np.ndarray],
+        end_point: Optional[np.ndarray],
+        dims_displayed: list[int],
+    ) -> Optional[int]:
+        """Get the first non-background value encountered along a ray.
+
+        Parameters
+        ----------
+        start_point : np.ndarray
+            (n,) array containing the start point of the ray in data coordinates.
+        end_point : np.ndarray
+            (n,) array containing the end point of the ray in data coordinates.
+        dims_displayed : List[int]
+            The indices of the dimensions currently displayed in the viewer.
+
+        Returns
+        -------
+        value : int
+            The first non-zero value encountered along the ray. If a
+            non-zero value is not encountered, returns None.
+        """
+        return self._get_value_ray(
+            start_point=start_point,
+            end_point=end_point,
+            dims_displayed=dims_displayed,
+        )
 
     def _get_offset_data_position(self, position: npt.NDArray) -> npt.NDArray:
         """Adjust position for offset between viewer and data coordinates.

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -565,26 +565,45 @@ def test_value():
 
 
 @pytest.mark.parametrize(
-    ('position', 'view_direction', 'dims_displayed', 'world'),
+    (
+        'position',
+        'view_direction',
+        'dims_displayed',
+        'world',
+        'render_mode',
+        'result',
+    ),
     [
-        ((0, 0, 0), [1, 0, 0], [0, 1, 2], False),
-        ((0, 0, 0), [1, 0, 0], [0, 1, 2], True),
-        ((0, 0, 0, 0), [0, 1, 0, 0], [1, 2, 3], True),
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], False, 'mip', 0),
+        ((0, 0, 0), [1, 0, 0], [0, 1, 2], True, 'mip', 0),
+        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'mip', 1),
+        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'minip', 0),
+        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'average', 1 / 5),
+        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'translucent', 0),
+        # not quite as expected for additive
+        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'additive', 2),
+        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'iso', None),
+        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'attenuated_mip', 0),
+        ((0, 2, 2, 2), [0, 1, 0, 0], [1, 2, 3], False, 'mip', 1),
     ],
 )
-def test_value_3d(position, view_direction, dims_displayed, world):
-    """Currently get_value should return None in 3D"""
-    np.random.seed(0)
-    data = np.random.random((10, 15, 15))
-    layer = Image(data)
-    layer._slice_dims(Dims(ndim=3, ndisplay=3))
+def test_value_3d(
+    position, view_direction, dims_displayed, world, render_mode, result
+):
+    data = np.zeros((5, 5, 5, 5))
+    data[:, 2, 2, 2] = 1
+    layer = Image(data, rendering=render_mode)
+    layer._slice_dims(Dims(ndim=4, ndisplay=3))
     value = layer.get_value(
         position,
         view_direction=view_direction,
         dims_displayed=dims_displayed,
         world=world,
     )
-    assert value is None
+    if result is None:
+        assert value is None
+    else:
+        npt.assert_allclose(value, result)
 
 
 def test_message():


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/7126

# References and relevant issues
While trying to debug #7090 I realized it's pretty simple to get the code from `get_value_3d` in `Labels` to work with images. This is an independent change, so I figured I'd open a separate PR.


# Description
Essentially, I just moved the code for `get_value_ray` and `get_value_3d` to the common superclass, with a little change: instead of doing `np.flatnonzero` to find the first nonzero indices, I move that to a separate method that the two classes implem...